### PR TITLE
docs: remove rc from install guide

### DIFF
--- a/docs/content/1.get-started.md
+++ b/docs/content/1.get-started.md
@@ -12,10 +12,10 @@ main:
 
 ::code-group
   ```bash [Yarn]
-  yarn add --dev @nuxtjs/prismic@rc
+  yarn add --dev @nuxtjs/prismic
   ```
   ```bash [NPM]
-  npm install --save-dev @nuxtjs/prismic@rc
+  npm install --save-dev @nuxtjs/prismic
   ```
 ::
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (a non-breaking change which is related to package maintenance)

## Description

Updates the docs to reflect that `rc` is not needed anymore after v3 stable release

## Checklist:

- [x] My change requires an update to the official documentation.