### PR TITLE
fix: opt in to `import.meta.*` properties

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -36,7 +36,7 @@ export default defineNuxtModule<PrismicModuleOptions>({
 	meta: {
 		name: '@nuxtjs/prismic',
 		configKey: 'prismic',
-		compatibility: { nuxt: '^3.0.0' }
+		compatibility: { nuxt: '^3.7.0' }
 	},
 	defaults: nuxt => ({
 		endpoint: '',

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -36,7 +36,7 @@ export default defineNuxtPlugin((nuxtApp) => {
 		const previewCookie = useCookie('io.prismic.preview').value
 
 		// Update client with req when running server side
-		if (process.server) {
+		if (import.meta.server) {
 			prismicPlugin.client.enableAutoPreviewsFromReq(useRequestEvent()?.req)
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This is a very early PR to make this module compatible with [changes we expect to release in Nuxt v5](https://github.com/nuxt/nuxt/issues/25323).

In [Nuxt v3.7.0](https://github.com/nuxt/nuxt/releases/tag/v3.7.0) we added support for `import.meta.*` (see [original PR](https://github.com/nuxt/nuxt/pull/22428)) and we've been gradually updating docs and moving across from the old `process.*` patterned variables.

As I'm sure you're aware, these variables are replaced at build-time and enable tree-shaking in bundled code.
This change affects _runtime_ code (that is, that is processed by the Nuxt bundler, like vite or webpack) rather than code running in Node. So it really doesn't matter what the string is, but it makes more sense in an ESM-world to use `import.meta` rather than `process`.

(It might be worth updating the module compatibility as well to indicate it needs to have Nuxt v3.7.0+, but I'll leave that with you if you think this is a good approach.)

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [ ] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [ ] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
