### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/docs/content/1.get-started.md
+++ b/docs/content/1.get-started.md
@@ -9,18 +9,9 @@ main:
 # Getting Started
 
 1. Install dependency
-
-::code-group
-  ```bash [nuxi]
-  npx nuxi module add prismic
-  ```
-  ```bash [Yarn]
-  yarn add --dev @nuxtjs/prismic
-  ```
-  ```bash [npm]
-  npm install --save-dev @nuxtjs/prismic
-  ```
-::
+```bash
+npx nuxi@latest module add prismic
+```
 
 2. Update Nuxt config
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description


This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏


## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [ ] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [ ] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
