### PR TITLE
Fix types for runtime/plugin.ts not being created correctly

### DIFF
--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -1,8 +1,8 @@
 import { isRepositoryEndpoint, getRepositoryName, type Client } from '@prismicio/client'
 import { createPrismic } from '@prismicio/vue'
 
+import { defineNuxtPlugin } from 'nuxt/app'
 import type { PrismicModuleOptions } from '../types'
-import { defineNuxtPlugin } from '#app'
 import NuxtLink from '#app/components/nuxt-link'
 import { useCookie, useRequestEvent, onNuxtReady, refreshNuxtData, useHead, useRuntimeConfig, useRouter } from '#imports'
 

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -2,8 +2,9 @@ import { isRepositoryEndpoint, getRepositoryName, type Client } from '@prismicio
 import { createPrismic } from '@prismicio/vue'
 
 import type { PrismicModuleOptions } from '../types'
+import { defineNuxtPlugin } from '#app'
 import NuxtLink from '#app/components/nuxt-link'
-import { defineNuxtPlugin, useCookie, useRequestEvent, onNuxtReady, refreshNuxtData, useHead, useRuntimeConfig, useRouter } from '#imports'
+import { useCookie, useRequestEvent, onNuxtReady, refreshNuxtData, useHead, useRuntimeConfig, useRouter } from '#imports'
 
 // @ts-expect-error vfs cannot be resolved here
 import _client from '#build/prismic/proxy/client'


### PR DESCRIPTION
## Types of changes

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

At some point, I think following https://github.com/nuxt-modules/prismic/pull/214, the following error started to happen following a `pnpm build:module`:

> src/runtime/plugin.client.ts(4,1): error TS2742: The inferred type of 'default' cannot be named without a reference to '.pnpm/nuxt@3.13.0_@parcel+watcher@2.4.1_@types+node@20.14.12_eslint@9.9.1_jiti@1.21.6__ioredis@5.4._sqyrdato2lgkvg37xa7csw3nz4/node_modules/nuxt/app'. This is likely not portable. A type annotation is necessary.
src/runtime/plugin.ts(15,1): error TS2742: The inferred type of 'default' cannot be named without a reference to '.pnpm/nuxt@3.13.0_@parcel+watcher@2.4.1_@types+node@20.14.12_eslint@9.9.1_jiti@1.21.6__ioredis@5.4._sqyrdato2lgkvg37xa7csw3nz4/node_modules/nuxt/app'. This is likely not portable. A type annotation is necessary.

This can be seen in CI pipeline for the latest release https://github.com/nuxt-modules/prismic/actions/runs/10647703821

<img width="1343" alt="image" src="https://github.com/user-attachments/assets/b6df4231-aec9-4415-8a3c-9c206795c105">

This results in the generated `dist/runtime/plugin.client.d.ts` and `dist/runtime/plugin.d.ts` being empty.

![image](https://github.com/user-attachments/assets/9349f1af-eaec-4f38-89e7-dd0c6ad19cb5)

This causes an error in a wider nuxt application as the following lines of code have the `any` type

![image](https://github.com/user-attachments/assets/87042458-b04d-4762-9c1d-62de3c5b0b90)

![image](https://github.com/user-attachments/assets/19fc64fb-2c1f-4064-9307-5b9ea9b26506)

This PR fixes this error. Note - I don't have much experience with Nuxt plugins, I'm not sure if there are any consequences to importing from `nuxt/app` rather than `#imports`? Anyhow this results in the types being created correctly (alternative solution is to do a `as Plugin<{ prismic: PrismicPlugin}>` cast

<img width="517" alt="image" src="https://github.com/user-attachments/assets/8ad1810f-e208-423c-9fea-f44ed2f9c3c7">

## Checklist:

- [ ] My change requires an update to the official documentation.
- [ ] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.
